### PR TITLE
Remove outdated tools

### DIFF
--- a/app/api/plugins/[pluginId]/route.ts
+++ b/app/api/plugins/[pluginId]/route.ts
@@ -354,11 +354,13 @@ export const PUT = withUnkey(
             data: transformPlugin(pluginId, plugin),
           }),
           prismaClient.agent.update({ where: { id: pluginId }, data: agent }),
+          prismaClient.tool.deleteMany({
+            where: { id: { in: pluginTools.map((t) => t.id) } },
+          }),
           ...pluginTools.map((tool) =>
-            prismaClient.tool.upsert({
+            prismaClient.tool.update({
               where: { id: tool.id },
-              update: tool,
-              create: tool,
+              data: tool,
             })
           ),
         ]);


### PR DESCRIPTION
Currently, when a tool is removed from an agent and the agent updated, the old tools stays in the database. This is unrelated to known bugs, but might be a potential footgun to be removed.