### PR TITLE
Add `generate-sol-tx`, change chainIds to lowercased string[]

### DIFF
--- a/app/api/plugins/[pluginId]/route.ts
+++ b/app/api/plugins/[pluginId]/route.ts
@@ -192,7 +192,7 @@ export const POST = withUnkey(
         repo: assistantDefinition.repo || null,
         verified: false,
         chainIds:
-          assistantDefinition.chainIds?.map((cid) => cid.toString()) || [],
+          assistantDefinition.chainIds?.map((cid) => cid.toString().toLowerCase()) || [],
         tools: pluginTools.map((t) => t.id),
         primitives:
           assistantDefinition.tools
@@ -335,7 +335,7 @@ export const PUT = withUnkey(
           assistantDefinition.instructions || plugin.info.description || "",
         image: assistantDefinition.image || null,
         chainIds:
-          assistantDefinition.chainIds?.map((cid) => cid.toString()) || [],
+          assistantDefinition.chainIds?.map((cid) => cid.toString().toLowerCase()) || [],
         tools: pluginTools.map((t) => t.id),
         primitives:
           assistantDefinition.tools

--- a/app/primitives/index.ts
+++ b/app/primitives/index.ts
@@ -7,6 +7,7 @@ export enum BittePrimitiveName {
   GET_TOKEN_METADATA = 'getTokenMetadata',
   GENERATE_EVM_TX = 'generate-evm-tx',
   GENERATE_SUI_TX = 'generate-sui-tx',
+  GENERATE_SOL_TX = 'generate-sol-tx',
   RENDER_CHART = 'render-chart',
   SIGN_MESSAGE = 'sign-message',
   GET_PORTFOLIO = 'get-portfolio',

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,6 +15,7 @@ export const COLLECTIONS = {
 export const BittePrimitiveNames = [
   "create-drop",
   "generate-evm-tx",
+  "generate-sol-tx",
   "generate-image",
   "generate-transaction",
   "getSwapTransactions",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -63,7 +63,7 @@ export type BitteAgentBase = {
   instructions: string;
   tools?: BitteToolSpec[];
   image?: string;
-  chainIds?: number[];
+  chainIds?: string[];
   categories?: string[];
   repo?: string;
 };


### PR DESCRIPTION
- This should fix the issues with creating agents with non-number chain ids like 'solana', 'sui', 'cardano'...
- Converted to lower case to make ids consistent
- Added `generate-sol-tx` to primitive names